### PR TITLE
feat: Add v2 endpoint for structured file creation errors

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -54,6 +54,145 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Files'
+  /v2/files/create:
+    post:
+      tags: ['ACH Files']
+      summary: Create File
+      description: Create a new File object from either the plaintext or JSON representation.
+      operationId: createFileV2
+      parameters:
+        - name: X-Request-ID
+          in: header
+          description: Optional Request ID allows application developer to trace requests through the system's logs
+          example: "rs4f9915"
+          schema:
+            type: string
+        - name: skipAll
+          in: query
+          description: Optional parameter to disable all validation checks for a File
+          schema:
+            type: boolean
+        - name: requireABAOrigin
+          in: query
+          description: Optional parameter to configure ImmediateOrigin validation
+          schema:
+            type: boolean
+        - name: bypassOriginValidation
+          in: query
+          description: Optional parameter to configure ImmediateOrigin validation
+          schema:
+            type: boolean
+        - name: bypassDestinationValidation
+          in: query
+          description: Optional parameter to configure ImmediateDestination validation
+          schema:
+            type: boolean
+        - name: customTraceNumbers
+          in: query
+          description: Optional parameter to configure ImmediateDestination validation
+          schema:
+            type: boolean
+        - name: allowZeroBatches
+          in: query
+          description: Optional parameter to configure ImmediateDestination validation
+          schema:
+            type: boolean
+        - name: allowMissingFileHeader
+          in: query
+          description: Optional parameter to configure ImmediateDestination validation
+          schema:
+            type: boolean
+        - name: allowMissingFileControl
+          in: query
+          description: Optional parameter to configure ImmediateDestination validation
+          schema:
+            type: boolean
+        - name: bypassCompanyIdentificationMatch
+          in: query
+          description: Optional parameter to configure ImmediateDestination validation
+          schema:
+            type: boolean
+        - name: customReturnCodes
+          in: query
+          description: Optional parameter to configure ImmediateDestination validation
+          schema:
+            type: boolean
+        - name: unequalServiceClassCode
+          in: query
+          description: Optional parameter to configure ImmediateDestination validation
+          schema:
+            type: boolean
+        - name: allowUnorderedBatchNumbers
+          in: query
+          description: Allow a file to be read with unordered batch numbers.
+          schema:
+            type: boolean
+        - name: allowInvalidCheckDigit
+          in: query
+          description: Allow the CheckDigit field in EntryDetail to differ from the expected calculation
+          schema:
+            type: boolean
+        - name: unequalAddendaCounts
+          in: query
+          description: Optional parameter to configure UnequalAddendaCounts validation
+          schema:
+            type: boolean
+        - name: preserveSpaces
+          in: query
+          description: Optional parameter to save all padding spaces
+          schema:
+            type: boolean
+        - name: allowInvalidAmounts
+          in: query
+          description: Optional parameter to save all padding spaces
+          schema:
+            type: boolean
+        - name: allowSpecialCharacters
+          in: query
+          description: Optional parameter to permit a wider range of UTF-8 characters in alphanumeric fields
+          schema:
+            type: boolean
+      requestBody:
+        description: Content of the ACH file (in json or raw text)
+        required: true
+        content:
+          text/plain:
+            schema:
+              description: A plaintext ACH file
+              type: string
+              example: |
+               101 23138010401210428821906240000A094101Federal Reserve Bank   My Bank Name
+               5225Name on Account                     121042882 PPDREG.SALARY      190625   1121042880000001
+               62723138010412345678         0100000000               Receiver Account Name   0121042880000001
+               82250000010023138010000100000000000000000000121042882                          121042880000001
+               9000001000001000000010023138010000100000000000000000000
+               9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999
+               9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999
+               9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999
+               9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999
+               9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateFile'
+      responses:
+        '200':
+          description: A JSON object containing a new File
+          headers:
+            Location:
+              description: The location of the new resource
+              schema:
+                type: string
+                format: uri
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateFileResponse'
+        '400':
+          description: "Invalid File Header Object"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StructuredErrorResponse'
   /files/{fileID}:
     post:
       tags: ['ACH Files']
@@ -2664,6 +2803,34 @@ components:
             $ref: '#/components/schemas/File'
         conditions:
           $ref: '#/components/schemas/MergeConditions'
+    StructuredErrorResponse:
+      properties:
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/StructuredError'
+    StructuredError:
+      properties:
+        lineNumber:
+          type: integer
+          description: Line number at which the record appears in the file.
+          example: 138
+        recordType:
+          type: string
+          description: The type of record that the error occurred on.
+          example: "EntryDetail"
+        errorType:
+          type: string
+          description: The type of error that occurred.
+          example: "FieldError"
+        fieldName:
+          type: string
+          description: The name of the field that the error occurred on.
+          example: "PaymentTypeCode"
+        message:
+          type: string
+          description: A human-readable message describing the error.
+          example: "PaymentTypeCode is a required field"
     MergeFilesResponse:
       properties:
         files:

--- a/server/errors.go
+++ b/server/errors.go
@@ -1,0 +1,105 @@
+// Licensed to The Moov Authors under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. The Moov Authors licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/moov-io/ach"
+	"github.com/moov-io/base"
+)
+
+type StructuredErrorResponse struct {
+	Errors []StructuredError `json:"errors"`
+}
+
+type StructuredError struct {
+	LineNumber int    `json:"lineNumber"`
+	RecordType string `json:"recordType"`
+	ErrorType  string `json:"errorType"`
+	FieldName  string `json:"fieldName"`
+	Message    string `json:"message"`
+}
+
+func buildStructuredErrors(err error) *StructuredErrorResponse {
+	if err == nil {
+		return nil
+	}
+
+	var el base.ErrorList
+	if errors.As(err, &el) {
+		var errs []StructuredError
+		for i := range el {
+			if list, ok := el[i].(base.ErrorList); ok {
+				resp := buildStructuredErrors(list)
+				if resp != nil {
+					errs = append(errs, resp.Errors...)
+				}
+			}
+
+			var fe *ach.FieldError
+			if errors.As(el[i], &fe) {
+				errs = append(errs, StructuredError{
+					ErrorType: "FieldError",
+					FieldName: fe.FieldName,
+					Message:   fe.Err.Error(),
+				})
+			}
+		}
+		return &StructuredErrorResponse{Errors: errs}
+	}
+
+	var fe *ach.FieldError
+	if errors.As(err, &fe) {
+		return &StructuredErrorResponse{
+			Errors: []StructuredError{
+				{
+					ErrorType: "FieldError",
+					FieldName: fe.FieldName,
+					Message:   fe.Err.Error(),
+				},
+			},
+		}
+	}
+
+	// fallback
+	return &StructuredErrorResponse{
+		Errors: []StructuredError{
+			{
+				Message: err.Error(),
+			},
+		},
+	}
+}
+
+func encodeStructuredError(_ context.Context, err error, w http.ResponseWriter) {
+	if err == nil {
+		err = ErrFoundABug
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(codeFrom(err))
+
+	resp := buildStructuredErrors(err)
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		w.Write([]byte(fmt.Sprintf("problem rendering structured json: %v", err)))
+	}
+}

--- a/server/routing.go
+++ b/server/routing.go
@@ -127,6 +127,20 @@ func MakeHTTPHandler(s Service, repo Repository, kitlog gokitlog.Logger) http.Ha
 		encodeResponse,
 		options...,
 	))
+
+	v2Options := []httptransport.ServerOption{
+		httptransport.ServerErrorLogger(kitlog),
+		httptransport.ServerErrorEncoder(encodeStructuredError),
+		httptransport.ServerBefore(saveCORSHeadersIntoContext()),
+		httptransport.ServerAfter(respondWithSavedCORSHeaders()),
+	}
+	r.Methods("POST").Path("/v2/files/create").Handler(httptransport.NewServer(
+		createFileEndpointV2(s, repo, logger),
+		decodeCreateFileRequest,
+		encodeResponse,
+		v2Options...,
+	))
+
 	r.Methods("POST").Path("/files/{fileID}").Handler(httptransport.NewServer(
 		createFileEndpoint(s, repo, logger),
 		decodeCreateFileRequest,


### PR DESCRIPTION
This commit introduces a new `/v2/files/create` endpoint that returns structured JSON errors upon validation failure. The existing `/files/create` endpoint is unchanged.

The new endpoint provides a structured error response, which allows clients to programmatically handle errors without parsing strings.